### PR TITLE
feat: tweaked the portal tile entity to be toggleable

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/autoportal/AutoPortalTileEntity.java
+++ b/src/main/java/net/portalmod/common/sorted/autoportal/AutoPortalTileEntity.java
@@ -102,6 +102,9 @@ public class AutoPortalTileEntity extends TileEntity implements ITickableTileEnt
                 if(indicatorInfo.allIndicatorsActivated) {
                     openPortal(blockState);
                     return;
+                } else {
+                    closePortal();
+                    return;
                 }
             }
         }

--- a/src/main/resources/assets/portalmod/lang/en_us.json
+++ b/src/main/resources/assets/portalmod/lang/en_us.json
@@ -171,9 +171,10 @@
   "tooltip.portalmod.trigger_4": "- §6Wrench + Crouch§7: Change entity type",
 
   "tooltip.portalmod.autoportal_1": "Can automatically open §9Portals§7, when linked to a §9Portal Gun§7",
-  "tooltip.portalmod.autoportal_2": "- Activated by adjacent §bAntline Indicators§7",
-  "tooltip.portalmod.autoportal_3": "- §6Wrench§7: Change between primary & secondary §9Portal§7",
-  "tooltip.portalmod.autoportal_4": "- §6Wrench + Offhand Portal Gun§7: Link to this §9Portal Gun§7",
+  "tooltip.portalmod.autoportal_2": "- Activates when powered by adjacent §bAntline Indicators§7",
+  "tooltip.portalmod.autoportal_3": "- Deactivates when not powered by adjacent §bAntline Indicators§7",
+  "tooltip.portalmod.autoportal_4": "- §6Wrench§7: Change between primary & secondary §9Portal§7",
+  "tooltip.portalmod.autoportal_5": "- §6Wrench + Offhand Portal Gun§7: Link to this §9Portal Gun§7",
 
   "tooltip.portalmod.chamber_lights_1": "Lights up test chambers",
   "tooltip.portalmod.chamber_lights_2": "- Turns off when powered by §cRedstone§7",


### PR DESCRIPTION
- [X] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- This makes it so the AutoPortal once unpowered, removes the portal. If a user would want it to be persistent, then they can set the input to be toggleable or persistent using the Wrench!

## Linked issues:
- Adds #129
