### PR TITLE
Fix link to Contributing Guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Contributing
 
-PortalMod is our passion project, and we manage development closely to maintain its specific vision. Please read our **[Contributing Guidelines](../../blob/main/CONTRIBUTING.md)** if you want to contribute.
+PortalMod is our passion project, and we manage development closely to maintain its specific vision. Please read our **[Contributing Guidelines](../../blob/master/CONTRIBUTING.md)** if you want to contribute.
 
 ---
 Find more information at [portalmod.net](https://portalmod.net/).


### PR DESCRIPTION
Updated link to Contributing Guidelines to use 'master' branch, than the main branch.

- [X] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixes ReadMe using the wrong branch for the link to contributing guides

