### PR TITLE
Fizzler to check local player before clearing portals

### DIFF
--- a/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
+++ b/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
@@ -96,9 +96,12 @@ public abstract class PlayerEntityMixin extends LivingEntity implements IClientT
 
     @Override
     public void onTouchingFizzler() {
-        if (this.isSpectator()) return;
+        PlayerEntity player = (PlayerEntity)(Object)this;
 
-        PortalGun.fizzleGunsInInventory((PlayerEntity) (Object) this);
+        if (player.isSpectator()) return;
+        if (!player.isLocalPlayer()) return;
+
+        PortalGun.fizzleGunsInInventory(player);
     }
 
     @Inject(


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a bug where being near a player walking through a fizzler also resets your portals.

## Linked issues:
- Fixes #153