### PR TITLE
compat: essentials fix

### DIFF
--- a/src/main/java/net/portalmod/core/init/KeyInit.java
+++ b/src/main/java/net/portalmod/core/init/KeyInit.java
@@ -3,18 +3,21 @@ package net.portalmod.core.init;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.portalmod.PortalMod;
-
-import java.awt.event.KeyEvent;
+import org.lwjgl.glfw.GLFW;
 
 public class KeyInit {
-    private KeyInit() {}
-    public static void init() {}
-    
-    public static final KeyBinding PORTALGUN_INTERACT = registerKey("portalgun_interact", KeyEvent.VK_E);
 
-    private static KeyBinding registerKey(String name, int keycode) {
-        final KeyBinding key = new KeyBinding("key." + PortalMod.MODID + "." + name, keycode, "key.category." + PortalMod.MODID);
-        ClientRegistry.registerKeyBinding(key);
-        return key;
+    private KeyInit() {}
+
+    public static KeyBinding PORTALGUN_INTERACT;
+
+    public static void init() {
+        PORTALGUN_INTERACT = new KeyBinding(
+                "key." + PortalMod.MODID + ".portalgun_interact",
+                GLFW.GLFW_KEY_E,
+                "key.category." + PortalMod.MODID
+        );
+
+        ClientRegistry.registerKeyBinding(PORTALGUN_INTERACT);
     }
 }


### PR DESCRIPTION
- [X] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a bug where the key binds initialise too early that causes a conflict with essentials

## Linked issues:
- Fixes #118 

<img width="2559" height="1391" alt="image" src="https://github.com/user-attachments/assets/923bd6aa-5135-4b3b-9887-097bd1a2395c" />


