### PR TITLE
compat: shader downgrading by @YassiGame

### DIFF
--- a/src/main/resources/assets/portalmod/shaders/blit/blit.fsh
+++ b/src/main/resources/assets/portalmod/shaders/blit/blit.fsh
@@ -1,10 +1,9 @@
-#version 130
+#version 120
 
 uniform sampler2D texture;
 
-in vec2 coords;
-out vec4 color;
+varying vec2 coords;
 
 void main() {
-    color = texture2D(texture, coords);
+    gl_FragColor = texture2D(texture, coords);
 }

--- a/src/main/resources/assets/portalmod/shaders/blit/blit.vsh
+++ b/src/main/resources/assets/portalmod/shaders/blit/blit.vsh
@@ -1,7 +1,7 @@
-#version 130
+#version 120
 
-in vec3 position;
-out vec2 coords;
+attribute vec3 position;
+varying vec2 coords;
 
 void main() {
     coords = gl_MultiTexCoord0.xy;

--- a/src/main/resources/assets/portalmod/shaders/gui/blit.fsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/blit.fsh
@@ -1,11 +1,10 @@
-#version 130
+#version 120
 
 uniform sampler2D texture;
 
-in vec2 coords;
-out vec4 color;
+varying vec2 coords;
 
 void main() {
-    color = texture2D(texture, coords);
-    color.a = (1. - pow(abs(coords.x), 10.)) * (1. - pow(abs(coords.y), 10.));
+    gl_FragColor = texture2D(texture, coords);
+    gl_FragColor.a = (1. - pow(abs(coords.x), 10.)) * (1. - pow(abs(coords.y), 10.));
 }

--- a/src/main/resources/assets/portalmod/shaders/gui/blit.vsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/blit.vsh
@@ -1,9 +1,9 @@
-#version 130
+#version 120
 
 uniform mat4 projection;
 
-in vec3 position;
-out vec2 coords;
+attribute vec3 position;
+varying vec2 coords;
 
 void main() {
     vec4 pos = projection * vec4(position, 1.);

--- a/src/main/resources/assets/portalmod/shaders/gui/color_picker/hue.fsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/color_picker/hue.fsh
@@ -1,16 +1,15 @@
-#version 130
+#version 120
 
 uniform float saturation;
 uniform float value;
 
-in vec2 coords;
-out vec4 color;
+varying vec2 coords;
 
 vec3 hsv2rgb(float h, float s, float v);
 
 void main() {
     float h = (1 - coords.y) * 360;
-    color = vec4(hsv2rgb(h, saturation, value), 1);
+    gl_FragColor = vec4(hsv2rgb(h, saturation, value), 1);
 }
 
 vec3 hsv2rgb(float h, float s, float v) {

--- a/src/main/resources/assets/portalmod/shaders/gui/color_picker/solid.fsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/color_picker/solid.fsh
@@ -1,16 +1,15 @@
-#version 130
+#version 120
 
 uniform float hue;
 uniform float saturation;
 uniform float value;
 
-in vec2 coords;
-out vec4 color;
+varying vec2 coords;
 
 vec3 hsv2rgb(float h, float s, float v);
 
 void main() {
-    color = vec4(hsv2rgb(hue, saturation, value), 1);
+    gl_FragColor = vec4(hsv2rgb(hue, saturation, value), 1);
 }
 
 vec3 hsv2rgb(float h, float s, float v) {

--- a/src/main/resources/assets/portalmod/shaders/gui/color_picker/sv.fsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/color_picker/sv.fsh
@@ -1,11 +1,10 @@
-#version 130
+#version 120
 
 uniform float hue;
 uniform float valMin;
 uniform float valMax;
 
-in vec2 coords;
-out vec4 color;
+varying vec2 coords;
 
 vec3 hsv2rgb(float h, float s, float v);
 
@@ -13,7 +12,7 @@ void main() {
     float h = hue;
     float s = coords.x;
     float v = coords.y * (valMax - valMin) + valMin;
-    color = vec4(hsv2rgb(h, s, v), 1);
+    gl_FragColor = vec4(hsv2rgb(h, s, v), 1);
 }
 
 vec3 hsv2rgb(float h, float s, float v) {

--- a/src/main/resources/assets/portalmod/shaders/gui/color_picker/vertex.vsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/color_picker/vertex.vsh
@@ -1,10 +1,10 @@
-#version 130
+#version 120
 
 uniform mat4 modelView;
 uniform mat4 projection;
 
-in vec3 position;
-out vec2 coords;
+attribute vec3 position;
+varying vec2 coords;
 
 void main() {
     vec4 pos = projection * modelView * vec4(position, 1);

--- a/src/main/resources/assets/portalmod/shaders/gui/loader/loader.vsh
+++ b/src/main/resources/assets/portalmod/shaders/gui/loader/loader.vsh
@@ -1,6 +1,6 @@
-#version 130
+#version 120
 
-in vec3 position;
+attribute vec3 position;
 
 varying vec2 uv;
 

--- a/src/main/resources/assets/portalmod/shaders/portal/frame.fsh
+++ b/src/main/resources/assets/portalmod/shaders/portal/frame.fsh
@@ -5,8 +5,12 @@ uniform int frameCount;
 uniform int frameIndex;
 
 varying vec2 texCoord;
+varying float clipDistance;
 
 void main() {
+    if(clipDistance < 0.)
+        discard;
+
     vec2 uv = texCoord;
     uv.y /= float(frameCount);
     uv.x = 1. - uv.x;

--- a/src/main/resources/assets/portalmod/shaders/portal/highlight.fsh
+++ b/src/main/resources/assets/portalmod/shaders/portal/highlight.fsh
@@ -4,8 +4,12 @@ uniform sampler2D texture;
 uniform float intensity;
 
 varying vec2 texCoord;
+varying float clipDistance;
 
 void main() {
+    if(clipDistance < 0.)
+        discard;
+
     gl_FragDepth = gl_FragCoord.z - 0.00001 * gl_FragCoord.w;
     gl_FragColor = texture2D(texture, texCoord);
 

--- a/src/main/resources/assets/portalmod/shaders/portal/mask.fsh
+++ b/src/main/resources/assets/portalmod/shaders/portal/mask.fsh
@@ -3,8 +3,12 @@
 uniform sampler2D texture;
 
 varying vec2 texCoord;
+varying float clipDistance;
 
 void main() {
+    if(clipDistance < 0.)
+        discard;
+
     gl_FragColor = texture2D(texture, texCoord);
 
     if(gl_FragCoord.z < .95) {

--- a/src/main/resources/assets/portalmod/shaders/portal/vertex.vsh
+++ b/src/main/resources/assets/portalmod/shaders/portal/vertex.vsh
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 
 attribute vec4 position;
 
@@ -10,12 +10,13 @@ uniform vec3 clipVec;
 uniform vec3 clipPos;
 
 varying vec2 texCoord;
+varying float clipDistance;
 
 void main() {
     vec4 worldPos = model * position;
     vec4 outPos = projection * (view * worldPos);
     texCoord = 1. - gl_MultiTexCoord0.xy;
+    clipDistance = (clipPlaneEnabled != 0) ? dot(worldPos.xyz - clipPos, clipVec) : 1.;
 
     gl_Position = outPos;
-    gl_ClipDistance[0] = (clipPlaneEnabled != 0) ? dot(worldPos.xyz - clipPos, clipVec) : 1.;
 }


### PR DESCRIPTION
- [X] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Downgrading shaders from 130 to 120, for more information read https://github.com/snowy-shack/PortalMod/issues/119 by @YassiGame

## Linked issues:
- Fixes #119 

I’ve tested the shader downgrades on Windows, and they seem to be working consistently. From Yassi’s POV, everything appears to be working on their side as well.

There's is a random bug where the screen goes black however I believe it's the result of #131 

Windows:
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/55f10d21-14af-4bd2-ba18-83c77f9ed70a" />

Mac:
<img width="1708" height="960" alt="image" src="https://github.com/user-attachments/assets/cb83de46-1ad1-4fb3-9287-69bc6dbdba43" />

