### PR TITLE
Make fizzler handling server-authoritative

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/portalgun/CPortalGunInteractionPacket.java
+++ b/src/main/java/net/portalmod/common/sorted/portalgun/CPortalGunInteractionPacket.java
@@ -165,6 +165,10 @@ public class CPortalGunInteractionPacket implements AbstractPacket<CPortalGunInt
                     break;
 
                 case FIZZLE:
+                    // Needed for tunneling cases the server-side tick can miss (the server
+                    // doesn't keep old positions/velocity for players). Trusted for the
+                    // SENDER only -- getSender() guarantees we only touch the sending
+                    // player's own guns, not anyone else's.
                     PortalGun.fizzleGunsInInventory(player);
                     break;
             }

--- a/src/main/java/net/portalmod/common/sorted/portalgun/PortalGun.java
+++ b/src/main/java/net/portalmod/common/sorted/portalgun/PortalGun.java
@@ -452,6 +452,13 @@ public class PortalGun extends Item {
 
     public static void fizzleGunsInInventory(PlayerEntity player) {
         if (player.level.isClientSide) {
+            // The server does not retain a player's old position or velocity, so it can miss
+            // fast/oblique fizzler traversal where neither the old nor the new bounding box
+            // intersects the fizzler but the swept segment between them does. The local
+            // client has the full movement data and is the one that reliably catches this,
+            // so it asks the server to fizzle on its behalf. The server handler uses
+            // getSender(), so only the sending player's own guns are affected -- and the
+            // PlayerEntityMixin guard makes sure only the LOCAL player sends it.
             PacketInit.INSTANCE.sendToServer(new CPortalGunInteractionPacket.Builder(PortalGunInteraction.FIZZLE).build());
             return;
         }

--- a/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
+++ b/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
@@ -96,9 +96,17 @@ public abstract class PlayerEntityMixin extends LivingEntity implements IClientT
 
     @Override
     public void onTouchingFizzler() {
-        if (this.isSpectator()) return;
+        PlayerEntity player = (PlayerEntity)(Object)this;
 
-        PortalGun.fizzleGunsInInventory((PlayerEntity) (Object) this);
+        if (player.isSpectator()) return;
+        // Every connected client ticks remote-player replicas too, so without this guard each
+        // client would send a FIZZLE packet for itself whenever any other player's replica
+        // walked through a fizzler -- cascading into all online players' portals closing.
+        // Only the client controlling this player (local) may send the packet; the server-side
+        // tick (isClientSide=false) still runs as a best-effort fallback.
+        if (player.level.isClientSide && !player.isLocalPlayer()) return;
+
+        PortalGun.fizzleGunsInInventory(player);
     }
 
     @Inject(


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

I have tried to run the PR #154 and it did not fix the issue.

## This PR makes the following changes:
- Detect fizzler intersections on the server tick, ignore client FIZZLE packets, and no-op client-side hooks to prevent outdated or malicious clients from forcing fizzling and causing multiplayer desyncs.

This has also been battle tested on the current public server hosted by pugge_linux on discord.

## Linked issues:
- Fixes #153