### PR TITLE
Add server-only rule to control portal overwrite

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/portal/PortalManager.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalManager.java
@@ -51,7 +51,7 @@ public class PortalManager extends WorldSavedData {
         List<Pair<UUID, PortalEnd>> completedPlacements = new ArrayList<>();
         this.scheduledPlacements.forEach((key, info) -> {
             if(--info.tickCountdown <= 0) {
-                PortalEntity portal = PortalPlacer.placePortal(info.level, info.end, info.hue, info.gunUUID, info.position, info.face, info.upDirection, info.override, info.lookingDirections, info.player);
+                PortalEntity portal = PortalPlacer.placePortal(info.level, info.end, info.hue, info.gunUUID, info.position, info.face, info.upDirection, info.override, info.overwriteForeignPortals, info.lookingDirections, info.player);
                 info.onPlace.accept(portal);
 
                 completedPlacements.add(key);
@@ -65,8 +65,12 @@ public class PortalManager extends WorldSavedData {
     }
 
     public void schedulePlacement(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player, long tickCountdown, Consumer<PortalEntity> onPlace) {
+        schedulePlacement(level, end, hue, gunUUID, position, face, upDirection, override, false, lookingDirections, player, tickCountdown, onPlace);
+    }
+
+    public void schedulePlacement(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, boolean overwriteForeignPortals, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player, long tickCountdown, Consumer<PortalEntity> onPlace) {
         Pair<UUID, PortalEnd> key = new Pair<>(gunUUID, end);
-        this.scheduledPlacements.put(key, new PortalPlacementInfo(level, end, hue, gunUUID, position, face, upDirection, override, lookingDirections, player, tickCountdown, onPlace));
+        this.scheduledPlacements.put(key, new PortalPlacementInfo(level, end, hue, gunUUID, position, face, upDirection, override, overwriteForeignPortals, lookingDirections, player, tickCountdown, onPlace));
     }
 
     public void clearScheduledPlacements(UUID gunUUID) {
@@ -237,12 +241,13 @@ public class PortalManager extends WorldSavedData {
         public final Direction face;
         public final Direction upDirection;
         public final boolean override;
+        public final boolean overwriteForeignPortals;
         public final @Nullable Direction[] lookingDirections;
         public final @Nullable ServerPlayerEntity player;
         public long tickCountdown;
         public Consumer<PortalEntity> onPlace;
 
-        public PortalPlacementInfo(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player, long tickCountdown, Consumer<PortalEntity> onPlace) {
+        public PortalPlacementInfo(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, boolean overwriteForeignPortals, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player, long tickCountdown, Consumer<PortalEntity> onPlace) {
             this.level = level;
             this.end = end;
             this.hue = hue;
@@ -251,6 +256,7 @@ public class PortalManager extends WorldSavedData {
             this.face = face;
             this.upDirection = upDirection;
             this.override = override;
+            this.overwriteForeignPortals = overwriteForeignPortals;
             this.lookingDirections = lookingDirections;
             this.player = player;
             this.tickCountdown = tickCountdown;

--- a/src/main/java/net/portalmod/common/sorted/portal/PortalPlacer.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalPlacer.java
@@ -87,15 +87,16 @@ public class PortalPlacer {
                 portal -> new Vec3(portal.getNormal()).dot(new Vec3(face)) > 0.99
                         && new Vec3(portal.position()).choose(face.getAxis()) - finalPosition.choose(face.getAxis()) < 0.01
                         && !(portal.getGunUUID().equals(gunUUID) && portal.getEnd() == end));
-        List<PortalEntity> portalsInTheWay2 = PortalEntity.getPortals(level, portalAABB,
-                portal -> new Vec3(portal.getNormal()).dot(new Vec3(face)) > 0.99
-                        && new Vec3(portal.position()).choose(face.getAxis()) - finalPosition.choose(face.getAxis()) < 0.01
-                        && !(portal.getGunUUID().equals(gunUUID) && portal.getEnd() == end));
-        List<AxisAlignedBB> bumpingPortals = portalsInTheWay.stream().map(Entity::getBoundingBox).collect(Collectors.toList());
+        // override (autoportal) evicts everything in the way, nothing bumps.
+        // overwriteForeignPortals (player shot with the gamerule on) evicts foreign portals
+        // only -- same-gun portals still bump so self-bumping keeps working.
+        // Neither flag -> every portal in the way bumps (command / default player shot).
+        List<AxisAlignedBB> bumpingPortals = portalsInTheWay.stream()
+                .filter(portal -> !override && (!overwriteForeignPortals || portal.getGunUUID().equals(gunUUID)))
+                .map(Entity::getBoundingBox)
+                .collect(Collectors.toList());
 
-        if(!override) {
-            collision = AABBUtil.addBoxesToVoxelShape(collision, bumpingPortals).optimize();
-        }
+        collision = AABBUtil.addBoxesToVoxelShape(collision, bumpingPortals).optimize();
 
         // get vertices on valid surface
         List<AABBVertex> vertices = Collider.getFaceCorners(face.getOpposite(), portalAABB);
@@ -171,8 +172,23 @@ public class PortalPlacer {
         if(portalCollides(face, portalAABB, collision))
             return null;
 
-        if(override) {
-            portalsInTheWay2.forEach(portal -> PortalManager.getInstance().scheduleRemoval(portal));
+        if(override || overwriteForeignPortals) {
+            // Evict portals that still actually overlap the *final* portal AABB (i.e. after
+            // the bump reaction and texel snapping). Using the pre-reaction set here would
+            // kill portals the placement ended up dodging, and wouldn't catch portals the
+            // bump nudged the placement into.
+            // With override alone (autoportal): evict everything that overlaps.
+            // With overwriteForeignPortals alone (player shot): evict only foreign portals;
+            // same-gun ones stayed in the bump set above and didn't end up overlapping.
+            // The same-gun-same-end portal is always skipped because PortalManager.put
+            // handles that replacement on spawn.
+            AxisAlignedBB finalAABB = portalAABB;
+            PortalEntity.getPortals(level, finalAABB,
+                    portal -> new Vec3(portal.getNormal()).dot(new Vec3(face)) > 0.99
+                            && !(portal.getGunUUID().equals(gunUUID) && portal.getEnd() == end)
+                            && (override || !portal.getGunUUID().equals(gunUUID))
+                            && portal.getBoundingBox().intersects(finalAABB))
+                    .forEach(portal -> PortalManager.getInstance().scheduleRemoval(portal));
         }
 
         // Spawn the portal

--- a/src/main/java/net/portalmod/common/sorted/portal/PortalPlacer.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalPlacer.java
@@ -34,6 +34,22 @@ public class PortalPlacer {
     private static final BinaryOperator<Vec3> selectLeast = (o, n) -> n.magnitude() < o.magnitude() ? n : o;
 
     public static PortalEntity placePortal(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player) {
+        return placePortal(level, end, hue, gunUUID, position, face, upDirection, override, false, lookingDirections, player);
+    }
+
+    /**
+     * @param override                indiscriminately replace every portal in the way, no
+     *                                bumping. Original autoportal semantics -- untouched by
+     *                                this PR.
+     * @param overwriteForeignPortals additionally evict portals belonging to a different gun
+     *                                when they overlap the final placement. Portals from the
+     *                                same gun still bump the placement like normal, so
+     *                                self-bumping your own other-coloured portal keeps working.
+     *                                Driven by the {@code allowPortalOverwrite} gamerule for
+     *                                player shots. Ignored when {@code override} is already
+     *                                true (that's a strict superset).
+     */
+    public static PortalEntity placePortal(World level, PortalEnd end, String hue, UUID gunUUID, Vec3 position, Direction face, Direction upDirection, boolean override, boolean overwriteForeignPortals, @Nullable Direction[] lookingDirections, @Nullable ServerPlayerEntity player) {
         Vec3 forward = new Vec3(face);
         Vec3 up = new Vec3(upDirection);
         Vec3 right = up.clone().cross(forward);

--- a/src/main/java/net/portalmod/common/sorted/portalgun/PortalGun.java
+++ b/src/main/java/net/portalmod/common/sorted/portalgun/PortalGun.java
@@ -282,10 +282,15 @@ public class PortalGun extends Item {
         };
 
         if(!inFizzler) {
+            // Player shots never use the autoportal-style `override` (which would also kill
+            // your own other-coloured portal during a self-bump). Instead the gamerule drives
+            // overwriteForeignPortals, which only evicts portals that belong to a different
+            // gun; same-gun portals keep bumping as before.
+            boolean overwriteForeign = level.getGameRules().getBoolean(GameRuleInit.ALLOW_PORTAL_OVERWRITE);
             if(level.getGameRules().getBoolean(GameRuleInit.PORTAL_SLOWSHOT)) {
-                PortalManager.getInstance().schedulePlacement(level, end, hue, uuid.get(), position.clone(), face, up, false, Direction.orderedByNearest(player), (ServerPlayerEntity) player, ticks, onPlace);
+                PortalManager.getInstance().schedulePlacement(level, end, hue, uuid.get(), position.clone(), face, up, false, overwriteForeign, Direction.orderedByNearest(player), (ServerPlayerEntity) player, ticks, onPlace);
             } else {
-                portal = PortalPlacer.placePortal(level, end, hue, uuid.get(), position.clone(), face, up, false, Direction.orderedByNearest(player), (ServerPlayerEntity) player);
+                portal = PortalPlacer.placePortal(level, end, hue, uuid.get(), position.clone(), face, up, false, overwriteForeign, Direction.orderedByNearest(player), (ServerPlayerEntity) player);
                 onPlace.accept(portal);
             }
         } else {

--- a/src/main/java/net/portalmod/core/init/GameRuleInit.java
+++ b/src/main/java/net/portalmod/core/init/GameRuleInit.java
@@ -16,10 +16,15 @@ public class GameRuleInit {
 
     public static GameRules.RuleKey<GameRules.BooleanValue> PORTAL_SLOWSHOT;
     public static GameRules.RuleKey<GameRules.BooleanValue> USE_PORTALABLE_BLACKLIST;
+    public static GameRules.RuleKey<GameRules.BooleanValue> ALLOW_PORTAL_OVERWRITE;
 
     public static void registerAll() {
         PORTAL_SLOWSHOT = registerBoolean("portalSlowShot", GameRules.Category.PLAYER, false);
         USE_PORTALABLE_BLACKLIST = registerBoolean("usePortalableBlacklist", GameRules.Category.PLAYER, false);
+        // Server-only: the client does not need to know this value. The server consults it at
+        // portal-placement time and either evicts the foreign portal in the way or rejects the
+        // shot; no client-side behavior (rendering, UI, prediction) depends on it.
+        ALLOW_PORTAL_OVERWRITE = registerServerBoolean("allowPortalOverwrite", GameRules.Category.PLAYER, true);
     }
 
     private static <T extends GameRules.RuleValue<T>> GameRules.RuleKey<T> register(String name, GameRules.Category category, GameRules.RuleType<T> rule) {
@@ -31,6 +36,10 @@ public class GameRuleInit {
     private static GameRules.RuleKey<GameRules.BooleanValue> registerBoolean(String name, GameRules.Category category, boolean defaultValue) {
         return register(name, category, BooleanValueAccessor.pmCreate(defaultValue, (server, value) ->
                 PacketInit.INSTANCE.send(PacketDistributor.ALL.noArg(), new SUpdateBooleanGameRulePacket(name, value.get()))));
+    }
+
+    private static GameRules.RuleKey<GameRules.BooleanValue> registerServerBoolean(String name, GameRules.Category category, boolean defaultValue) {
+        return register(name, category, BooleanValueAccessor.pmCreate(defaultValue, (server, value) -> {}));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Register a server-only game rule to allow or deny overwriting existing portals and apply it during both scheduled and immediate portal placement. Use a server-only registration helper to avoid client sync for server-only behavior.

Gamerule is default false.

Current behaviour also allows to replace your own portals (blue with orange) 