### PR TITLE
Prevent entity hangs by deferring portal sweeps

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
@@ -195,23 +195,52 @@ public class PortalEntity extends Entity implements IEntityAdditionalSpawnData {
         Vec3 positionToCenterVector = new Vec3(entity.getBoundingBox().getCenter()).sub(entity.position());
 
         World level = entity.level;
+
+        // Do all cheap filters FIRST using an over-approximation of the travel path. pmCollide is
+        // very expensive (it sweeps voxel shapes within the entity's expanded AABB) and previously
+        // ran for every non-player entity tick, even ones that had no chance of teleporting. That
+        // made the server hang with a relatively small number of minecarts.
+        //
+        // The conservative AABB (expanded by the raw delta rather than the post-collision delta)
+        // is a superset of the real travel AABB, so any portal that would pass the real filter is
+        // still in this candidate list.
+        AxisAlignedBB conservativeTravelAABB = entity.getBoundingBox().expandTowards(delta);
+        Vec3 entityOldCenter = new Vec3(entity.getBoundingBox().getCenter());
+
+        List<PortalEntity> candidatePortals = getOpenPortals(level, conservativeTravelAABB, portal -> {
+            boolean correctDirection = entity.getDeltaMovement().dot(new Vec3(portal.getNormal()).to3d()) < 0;
+            if(!correctDirection)
+                return false;
+
+            // Already on / past the portal surface - can't "enter" it again this tick.
+            if(portal.canPointEnter(entityOldCenter, true))
+                return false;
+
+            if(!portal.isEntityAlignedToPortal(entity))
+                return false;
+
+            return justExited == null
+                    || new Vec3(portal.position()).sub(justExited.position()).dot(justExited.getNormal()) > 0
+                    || portal == justExited;
+        });
+
+        if(candidatePortals.isEmpty())
+            return delta;
+
+        // Only now pay for the full voxel-shape collision sweep, and only for the tight predicate
+        // that requires the true post-collision endpoint.
         Vector3d tmpDelta = ((EntityAccessor)entity).pmCollide(delta);
         AxisAlignedBB travelAABB = entity.getBoundingBox().expandTowards(tmpDelta);
 
-        List<PortalEntity> portals = getOpenPortals(level, travelAABB, portal -> {
-            Vec3 entityOldPos = new Vec3(entity.getBoundingBox().getCenter());
-            Vec3 entityPos = entityOldPos.clone().add(tmpDelta);
+        List<PortalEntity> portals = new ArrayList<>();
+        for(PortalEntity portal : candidatePortals) {
+            if(!portal.getBoundingBox().intersects(travelAABB))
+                continue;
 
-            boolean entering = !portal.canPointEnter(entityOldPos, true) && portal.canPointEnter(entityPos, false);
-            boolean correctDirection = entity.getDeltaMovement().dot(new Vec3(portal.getNormal()).to3d()) < 0;
-
-            return portal.isEntityAlignedToPortal(entity)
-                    && entering
-                    && correctDirection
-                    && (justExited == null
-                        || new Vec3(portal.position()).sub(justExited.position()).dot(justExited.getNormal()) > 0
-                        || portal == justExited);
-        });
+            Vec3 entityPos = entityOldCenter.clone().add(tmpDelta);
+            if(portal.canPointEnter(entityPos, false))
+                portals.add(portal);
+        }
 
         if(portals.isEmpty())
             return delta;

--- a/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
@@ -171,6 +171,16 @@ public class PortalEntity extends Entity implements IEntityAdditionalSpawnData {
         if(depth > 100 || (!entity.level.isClientSide && entity instanceof PlayerEntity))
             return delta;
 
+        // Guard against broken/extreme movement state. Without this the pmCollide call below
+        // expands the entity's AABB by delta and iterates every voxel shape inside it, which
+        // can hang the server for many seconds (see watchdog crashes with large entity counts).
+        if(!isFiniteVec(delta) || !isFiniteVec(entity.position()) || !isFiniteAABB(entity.getBoundingBox()))
+            return delta;
+
+        final double MAX_TELEPORT_DELTA = 64.0;
+        if(delta.lengthSqr() > MAX_TELEPORT_DELTA * MAX_TELEPORT_DELTA)
+            return delta;
+
         boolean inFluid = entity.isInWater() || entity.isInLava();
         boolean flying = entity instanceof PlayerEntity && ((PlayerEntity)entity).abilities.flying;
 
@@ -368,6 +378,15 @@ public class PortalEntity extends Entity implements IEntityAdditionalSpawnData {
     public static Vector3d teleportEntity(Entity entity, Vector3d delta) {
         ((ITeleportable2)entity).removeJustUsedPortal();
         return recursivelyTeleportEntity(entity, delta, null, 0);
+    }
+
+    private static boolean isFiniteVec(Vector3d v) {
+        return Double.isFinite(v.x) && Double.isFinite(v.y) && Double.isFinite(v.z);
+    }
+
+    private static boolean isFiniteAABB(AxisAlignedBB bb) {
+        return Double.isFinite(bb.minX) && Double.isFinite(bb.minY) && Double.isFinite(bb.minZ)
+                && Double.isFinite(bb.maxX) && Double.isFinite(bb.maxY) && Double.isFinite(bb.maxZ);
     }
 
     public static Vector3d doFunneling(Entity entity, Vector3d delta) {


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Prefilter portals using a conservative travel AABB and add finite/movement delta guards to avoid pathological collision voxel-shape scans, preventing server watchdog hangs with large entity counts.
