### PR TITLE
Fix: Repulsion Gel bounce reset for non-player entities (fixes #125)

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/gel/RepulsionGelBlock.java
+++ b/src/main/java/net/portalmod/common/sorted/gel/RepulsionGelBlock.java
@@ -162,7 +162,11 @@ public class RepulsionGelBlock extends AbstractGelBlock {
         if (entity.getDeltaMovement().y < -0.1) {
             if(entity.level.isClientSide) {
                 gelAffected.setBounced(false);
-                PacketInit.INSTANCE.sendToServer(new CRepulsionGelBouncePacket(false));
+                if (entity instanceof PlayerEntity) {
+                    PacketInit.INSTANCE.sendToServer(new CRepulsionGelBouncePacket(false));
+                }
+            } else{
+                gelAffected.setBounced(false);
             }
         } else {
             gelAffected.setLastNeurtalHeight((float) entity.getY());


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a bug where objects bounce only once

## Linked issues:
- Fixes #125 

