### PR TITLE
MacOS X Keybind Tooltip Display Fix

### DIFF
--- a/src/main/java/net/portalmod/core/util/ModUtil.java
+++ b/src/main/java/net/portalmod/core/util/ModUtil.java
@@ -10,6 +10,7 @@ import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Rotation;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
@@ -185,7 +186,7 @@ public class ModUtil {
         }
 
         if (!Screen.hasControlDown()) {
-            list.add(tooltipComponent("tooltip.portalmod.hold_control"));
+            list.add(tooltipComponent("tooltip.portalmod.hold_inspect_key", getModifierKeyName()));
             return;
         }
 
@@ -207,8 +208,14 @@ public class ModUtil {
         }
     }
 
-    public static IFormattableTextComponent tooltipComponent(String string) {
-        return new TranslationTextComponent(string).setStyle(TOOLTIP_STYLE);
+    public static IFormattableTextComponent tooltipComponent(String key, Object... args) {
+        return new TranslationTextComponent(key, args).setStyle(TOOLTIP_STYLE);
+    }
+
+    private static String getModifierKeyName() {
+        return Util.getPlatform() == Util.OS.OSX
+                ? "Command"
+                : "Ctrl";
     }
 
     public static float symmetricRandom(float width) {

--- a/src/main/java/net/portalmod/core/util/ModUtil.java
+++ b/src/main/java/net/portalmod/core/util/ModUtil.java
@@ -186,7 +186,7 @@ public class ModUtil {
         }
 
         if (!Screen.hasControlDown()) {
-            list.add(tooltipComponent("tooltip.portalmod.hold_inspect_key", getModifierKeyName()));
+            list.add(tooltipComponent("tooltip.portalmod.hold_control", getModifierKeyName()));
             return;
         }
 

--- a/src/main/resources/assets/portalmod/lang/en_us.json
+++ b/src/main/resources/assets/portalmod/lang/en_us.json
@@ -110,7 +110,7 @@
   "container.faithplate.enabled":  "Enabled",
   "container.faithplate.noTarget": "No Target Selected",
 
-  "tooltip.portalmod.hold_inspect_key": "Hold %s for info",
+  "tooltip.portalmod.hold_control": "Hold %s for info",
 
   "tooltip.portalmod.wrench": "Configures §aTesting Elements§7",
 

--- a/src/main/resources/assets/portalmod/lang/en_us.json
+++ b/src/main/resources/assets/portalmod/lang/en_us.json
@@ -110,7 +110,7 @@
   "container.faithplate.enabled":  "Enabled",
   "container.faithplate.noTarget": "No Target Selected",
 
-  "tooltip.portalmod.hold_control": "Hold Ctrl for info",
+  "tooltip.portalmod.hold_inspect_key": "Hold %s for info",
 
   "tooltip.portalmod.wrench": "Configures §aTesting Elements§7",
 


### PR DESCRIPTION
- [X] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a bug where the tooltip description uses the wrong key when on MacOS X

## Linked issues:
- Fixes #250

