### PR TITLE
Add and expand issue template checklists

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -12,8 +12,11 @@ body:
 
   - type: checkboxes
     attributes:
-      label: Latest Version
+      label: Checklist
       options:
+        - label: I have searched [GitHub](https://github.com/snowy-shack/PortalMod/issues?q=sort%3Aupdated-desc%20is%3Aissue) for my bug / issue
+          required: true
+        - label: I just clicked all the boxes in the checklist
         - label: This is the latest version of the mod
           required: true
 

--- a/.github/ISSUE_TEMPLATE/suggestions.yml
+++ b/.github/ISSUE_TEMPLATE/suggestions.yml
@@ -3,6 +3,13 @@ description: Suggest a new feature
 title: "Suggestion: "
 type: Feature
 body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched [GitHub](https://github.com/snowy-shack/PortalMod/issues?q=sort%3Aupdated-desc%20is%3Aissue) for my suggestion
+          required: true
+        - label: I just clicked all the boxes in the checklist
   - type: textarea
     attributes:
       label: What is your suggestion?


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Expand bug report checklist to require a GitHub search and relabel the section to improve duplicate detection and ensure latest-version confirmation.
- Add a checklist to the suggestion template requiring a prior GitHub search to improve triage quality.

If you don't want this you can just close it.