### PR TITLE
Fix fireball momentum not rotating through portals (Fixes #187)

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalEntity.java
@@ -6,6 +6,7 @@ import net.minecraft.client.renderer.ActiveRenderInfo;
 import net.minecraft.entity.*;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.DamagingProjectileEntity;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -339,7 +340,18 @@ public class PortalEntity extends Entity implements IEntityAdditionalSpawnData {
 
         delta = portal.teleportVector(new Vec3(delta)).to3d();
         entity.setDeltaMovement(portal.teleportVector(new Vec3(dm)).to3d());
-
+        if(entity instanceof DamagingProjectileEntity) {
+            DamagingProjectileEntity damagingProjectile = (DamagingProjectileEntity)entity;
+            Vec3 power = new Vec3(
+                    damagingProjectile.xPower,
+                    damagingProjectile.yPower,
+                    damagingProjectile.zPower
+            );
+            Vec3 teleportedPower = portal.teleportVector(power);
+            damagingProjectile.xPower = teleportedPower.x;
+            damagingProjectile.yPower = teleportedPower.y;
+            damagingProjectile.zPower = teleportedPower.z;
+        }
         OrthonormalBasis portalBasis = portal.getSourceBasis();
         OrthonormalBasis targetPortalBasis = targetPortal.getDestinationBasis();
         Mat4 changeOfBasisMatrix = portalBasis.getChangeOfBasisMatrix(targetPortalBasis);


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a bug where Fireball momentum through Portals is not rotated
- This also fixes it for Fireballs, Dragon Fireballs, and Wither skull

## Linked issues:
- Fixes #187 

## Note:
- Test this before merging last time this happened it failed on server and i cant test on server due to bad hardware