### PR TITLE
Fix game crash (Fixes #292)

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/button/SuperButtonBlock.java
+++ b/src/main/java/net/portalmod/common/sorted/button/SuperButtonBlock.java
@@ -225,7 +225,9 @@ public class SuperButtonBlock extends QuadBlock implements AntlineActivator {
     }
     
     private boolean isBeingPressed(World level, BlockPos pos) {
-        AxisAlignedBB trigger = this.getTrigger(level.getBlockState(pos), pos);
+        BlockState state = level.getBlockState(pos);
+        if (!(state.getBlock() instanceof SuperButtonBlock)) return false;
+        AxisAlignedBB trigger = this.getTrigger(state, pos);
 
         List<? extends Entity> entities = level.getEntitiesOfClass(LivingEntity.class, trigger, EntityPredicates.NO_SPECTATORS
                 .and(entity -> !entity.getType().is(EntityTagInit.BUTTON_NO_PRESS))


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Fixed a crash bug where a incomplete super button(a button with 1 part instead of 4) will crash the game

## Linked issues:
- Fixes #292 

## Note:
- Test this before merging last time this happened it failed on server and i cant test on server due to bad hardware