### PR TITLE
Fix portal teleport hunger drain

### DIFF
--- a/src/main/java/net/portalmod/common/sorted/portal/PortalMovementAccounting.java
+++ b/src/main/java/net/portalmod/common/sorted/portal/PortalMovementAccounting.java
@@ -1,0 +1,9 @@
+package net.portalmod.common.sorted.portal;
+
+public final class PortalMovementAccounting {
+    private PortalMovementAccounting() {}
+
+    public static boolean shouldSuppressMovementExhaustion(boolean justPortaled, float exhaustion) {
+        return justPortaled && exhaustion > 0.0F;
+    }
+}

--- a/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
+++ b/src/main/java/net/portalmod/mixins/entity/PlayerEntityMixin.java
@@ -25,6 +25,7 @@ import net.portalmod.common.sorted.faithplate.Flingable;
 import net.portalmod.common.sorted.portal.IClientTeleportable;
 import net.portalmod.common.sorted.portal.PortalEntity;
 import net.portalmod.common.sorted.portal.PortalHandler;
+import net.portalmod.common.sorted.portal.PortalMovementAccounting;
 import net.portalmod.common.sorted.portalgun.PortalGun;
 import net.portalmod.core.init.AttributeInit;
 import net.portalmod.core.init.CriteriaTriggerInit;
@@ -140,6 +141,19 @@ public abstract class PlayerEntityMixin extends LivingEntity implements IClientT
                 VoxelShapes.create(bb), IBooleanFunction.AND);
 
         return noCollision && noCubeCollision && noPortalCollision;
+    }
+
+    @Redirect(
+                        method = "checkMovementStatistics",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/player/PlayerEntity;causeFoodExhaustion(F)V"
+            )
+    )
+    private void pmSuppressPortalTeleportMovementExhaustion(PlayerEntity player, float exhaustion) {
+        if(!PortalMovementAccounting.shouldSuppressMovementExhaustion(this.clientJustPortaled, exhaustion)) {
+            player.causeFoodExhaustion(exhaustion);
+        }
     }
 
     @Unique

--- a/src/main/java/net/portalmod/mixins/network/ServerPlayNetHandlerMixin.java
+++ b/src/main/java/net/portalmod/mixins/network/ServerPlayNetHandlerMixin.java
@@ -10,8 +10,10 @@ import net.portalmod.common.sorted.portal.PortalServerProofManager;
 import net.portalmod.core.interfaces.ITeleportLerpable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerPlayNetHandler.class)
 public class ServerPlayNetHandlerMixin {
@@ -25,10 +27,17 @@ public class ServerPlayNetHandlerMixin {
     private boolean pmAvoidResettingFallDistance(boolean value) {
         IClientTeleportable player = ((IClientTeleportable)((ServerPlayNetHandler)(Object)this).player);
         if(player.getJustPortaled()) {
-            player.setJustPortaled(false);
             return false;
         }
         return value;
+    }
+
+    @Inject(
+                        method = "handleMovePlayer",
+            at = @At("RETURN")
+    )
+    private void pmClearPortalMovementState(CallbackInfo info) {
+        ((IClientTeleportable)((ServerPlayNetHandler)(Object)this).player).setJustPortaled(false);
     }
 
     @Redirect(

--- a/src/test/java/net/portalmod/common/sorted/portal/PortalMovementAccountingTest.java
+++ b/src/test/java/net/portalmod/common/sorted/portal/PortalMovementAccountingTest.java
@@ -1,0 +1,21 @@
+package net.portalmod.common.sorted.portal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PortalMovementAccountingTest {
+    @Test
+    public void suppressesMovementExhaustionForPortalTeleportDistance() {
+        Assert.assertTrue(PortalMovementAccounting.shouldSuppressMovementExhaustion(true, 10.0F));
+    }
+
+    @Test
+    public void keepsNormalMovementExhaustion() {
+        Assert.assertFalse(PortalMovementAccounting.shouldSuppressMovementExhaustion(false, 0.1F));
+    }
+
+    @Test
+    public void keepsNonPositiveExhaustionEvenAfterPortal() {
+        Assert.assertFalse(PortalMovementAccounting.shouldSuppressMovementExhaustion(true, 0.0F));
+    }
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guidelines](https://github.com/snowy-shack/PortalMod/blob/master/CONTRIBUTING.md)

## This PR makes the following changes:
- Suppress movement exhaustion from portal teleports to prevent unintended hunger drain
- Defer clearing portal state until after server move handling; centralize logic and add unit tests

## Linked issues:
- #239